### PR TITLE
Fix maketestfiles.sh

### DIFF
--- a/test/maketestfiles.sh
+++ b/test/maketestfiles.sh
@@ -179,10 +179,13 @@ for cspace in $cspaces; do
 						> $filter-$cspace-$depth-$order.$format \
 						2> $filter-$cspace-$depth-$order.log
 					;;
-				cgimagetopdf)
-					$filterpath/cgimagetopdf job user title 1 "" $basedir/testprint.jpg | $filterpath/cgpdftoraster job user \
+				cgimagetoraster)
+					($filterpath/cgimagetopdf job user title 1 \
+						"" \
+						$basedir/testprint.jpg | \
+					$filterpath/cgpdftoraster job user \
 						title 1 \
-						"ColorModel=$cspace cupsBitsPerColor=$depth cupsColorOrder=$order" \
+						"ColorModel=$cspace cupsBitsPerColor=$depth cupsColorOrder=$order") \
 						> $filter-$cspace-$depth-$order.$format \
 						2> $filter-$cspace-$depth-$order.log
 					;;


### PR DESCRIPTION
In the main loop of the script, a filter *`"cgimagetopdf"`*  is used.
This should really be *`"cgimagetoraster"`*.

Also, stuff it into a sub-shell (analog to the *`"pstoraster"`* filter, which really is *`"pstops | pstoraster"`*) since it is also composed of a chain, *`"cgimagetopdf | cgpdftoraster"`* .