### PR TITLE
Fix incorrect/duplicate include directive

### DIFF
--- a/RasterDisplay.cxx
+++ b/RasterDisplay.cxx
@@ -16,7 +16,7 @@
 #include <FL/fl_draw.H>
 #include <FL/Fl_Preferences.H>
 #include <stdio.h>
-#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>


### PR DESCRIPTION
The `free()` function is used but this function is declared in `stdlib.h`. Instead, `stdio.h` was included twice, I think the second one was supposed to be `stdlib.h`.