### PR TITLE
Fix/improve desktop integration

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -90,8 +90,8 @@ install: all @INSTALLDESKTOP@
 
 
 install-desktop:
-	$(MKDIR) $(BUILDROOT)$(desktopdir)/Development
-	cp rasterview.desktop $(BUILDROOT)$(desktopdir)/Development
+	$(MKDIR) $(BUILDROOT)$(desktopdir)
+	cp rasterview.desktop $(BUILDROOT)$(desktopdir)
 	$(MKDIR) $(BUILDROOT)$(datadir)/mimelnk/application
 	cp vnd.cups-raster.desktop $(BUILDROOT)$(datadir)/mimelnk/application
 	$(MKDIR) $(BUILDROOT)$(datadir)/mimelnk/image
@@ -110,7 +110,7 @@ uninstall: @UNINSTALLDESKTOP@
 
 
 uninstall-desktop:
-	$(RM) $(desktopdir)/Graphics/rasterview.desktop
+	$(RM) $(desktopdir)/rasterview.desktop
 	$(RM) $(datadir)/mimelnk/application/vnd.cups-raster.desktop
 	$(RM) $(datadir)/mimelnk/image/pwg-raster.desktop
 	$(RM) $(datadir)/mimelnk/image/urf.desktop

--- a/Makefile.in
+++ b/Makefile.in
@@ -101,6 +101,8 @@ install-desktop:
 	cp rasterview-32.png $(BUILDROOT)$(datadir)/icons/hicolor/32x32/apps/rasterview.png
 	$(MKDIR) $(BUILDROOT)$(datadir)/icons/hicolor/128x128/apps
 	cp rasterview-128.png $(BUILDROOT)$(datadir)/icons/hicolor/128x128/apps/rasterview.png
+	$(MKDIR) $(BUILDROOT)$(datadir)/mime/packages
+	cp rasterview.xml $(BUILDROOT)$(datadir)/mime/packages
 
 
 uninstall: @UNINSTALLDESKTOP@
@@ -114,6 +116,7 @@ uninstall-desktop:
 	$(RM) $(datadir)/mimelnk/image/urf.desktop
 	$(RM) $(datadir)/icons/hicolor/32x32/apps/rasterview.png
 	$(RM) $(datadir)/icons/hicolor/128x128/apps/rasterview.png
+	$(RM) $(datadir)/mime/packages/rasterview.xml
 
 
 # Make a disk image with the compiled program on macOS...

--- a/Makefile.in
+++ b/Makefile.in
@@ -92,11 +92,6 @@ install: all @INSTALLDESKTOP@
 install-desktop:
 	$(MKDIR) $(BUILDROOT)$(desktopdir)
 	cp rasterview.desktop $(BUILDROOT)$(desktopdir)
-	$(MKDIR) $(BUILDROOT)$(datadir)/mimelnk/application
-	cp vnd.cups-raster.desktop $(BUILDROOT)$(datadir)/mimelnk/application
-	$(MKDIR) $(BUILDROOT)$(datadir)/mimelnk/image
-	cp pwg-raster.desktop $(BUILDROOT)$(datadir)/mimelnk/image
-	cp urf.desktop $(BUILDROOT)$(datadir)/mimelnk/image
 	$(MKDIR) $(BUILDROOT)$(datadir)/icons/hicolor/32x32/apps
 	cp rasterview-32.png $(BUILDROOT)$(datadir)/icons/hicolor/32x32/apps/rasterview.png
 	$(MKDIR) $(BUILDROOT)$(datadir)/icons/hicolor/128x128/apps
@@ -111,9 +106,6 @@ uninstall: @UNINSTALLDESKTOP@
 
 uninstall-desktop:
 	$(RM) $(desktopdir)/rasterview.desktop
-	$(RM) $(datadir)/mimelnk/application/vnd.cups-raster.desktop
-	$(RM) $(datadir)/mimelnk/image/pwg-raster.desktop
-	$(RM) $(datadir)/mimelnk/image/urf.desktop
 	$(RM) $(datadir)/icons/hicolor/32x32/apps/rasterview.png
 	$(RM) $(datadir)/icons/hicolor/128x128/apps/rasterview.png
 	$(RM) $(datadir)/mime/packages/rasterview.xml

--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,7 @@ AC_SUBST([ARCHFLAGS])
 dnl See if we have the X11 desktop stuff used by GNOME and KDE...
 AC_MSG_CHECKING([if GNOME/KDE desktop is in use])
 desktopdir=""
-for dir in /usr/share/applications /usr/share/applnk /etc/X11/applnk; do
+for dir in /usr/share/applications; do
     AS_IF([test -d $dir], [
 	desktopdir=$dir
 	break

--- a/pwg-raster.desktop
+++ b/pwg-raster.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Type=MimeType
-MimeType=image/pwg-raster
-Icon=rasterview.png
-Patterns=*.pwg
-Name=PWG Raster File
-Comment=PWG Raster File
-Encoding=UTF-8

--- a/rasterview.desktop
+++ b/rasterview.desktop
@@ -1,11 +1,10 @@
 [Desktop Entry]
 Name=RasterView
 Comment=CUPS Raster Viewer
-TryExec=rasterview
 Exec=rasterview %F
-Icon=rasterview.png
+Icon=rasterview
 Terminal=false
 Type=Application
-MimeType=application/vnd.cups-raster
-Encoding=UTF-8
-Categories=Graphics;
+# image/x-cmu-raster is the shared-mime-info MIME for application/vnd.cups-raster
+MimeType=image/x-cmu-raster;image/pwg-raster;image/urf;
+Categories=Graphics;RasterGraphics;Viewer;2DGraphics;

--- a/rasterview.list.in
+++ b/rasterview.list.in
@@ -36,12 +36,6 @@ f 0644 root sys $desktopdir/rasterview.desktop rasterview.desktop
 d 0755 root sys $datadir/mime/packages -
 f 0644 root sys $datadir/mime/packages/rasterview.xml rasterview.xml
 
-d 0755 root sys $datadir/mimelnk/application -
-f 0644 root sys $datadir/mimelnk/application/vnd.cups-raster.desktop vnd.cups-raster.desktop
-
-d 0755 root sys $datadir/mimelnk/image -
-f 0644 root sys $datadir/mimelnk/image/pwg-raster.desktop pwg-raster.desktop
-
 d 0755 root sys $datadir/icons/hicolor/32x32/apps -
 f 0644 root sys $datadir/icons/hicolor/32x32/apps/rasterview.png rasterview-32.png
 

--- a/rasterview.list.in
+++ b/rasterview.list.in
@@ -30,8 +30,8 @@ $desktopdir=@desktopdir@
 # Files...
 f 0755 root sys $bindir/rasterview rasterview
 
-d 0755 root sys $desktopdir/Development -
-f 0644 root sys $desktopdir/Development/rasterview.desktop rasterview.desktop
+d 0755 root sys $desktopdir -
+f 0644 root sys $desktopdir/rasterview.desktop rasterview.desktop
 
 d 0755 root sys $datadir/mime/packages -
 f 0644 root sys $datadir/mime/packages/rasterview.xml rasterview.xml

--- a/rasterview.list.in
+++ b/rasterview.list.in
@@ -33,6 +33,9 @@ f 0755 root sys $bindir/rasterview rasterview
 d 0755 root sys $desktopdir/Development -
 f 0644 root sys $desktopdir/Development/rasterview.desktop rasterview.desktop
 
+d 0755 root sys $datadir/mime/packages -
+f 0644 root sys $datadir/mime/packages/rasterview.xml rasterview.xml
+
 d 0755 root sys $datadir/mimelnk/application -
 f 0644 root sys $datadir/mimelnk/application/vnd.cups-raster.desktop vnd.cups-raster.desktop
 

--- a/rasterview.xml
+++ b/rasterview.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="image/pwg-raster">
+    <comment>PWG raster image</comment>
+    <glob pattern="*.pwg"/>
+  </mime-type>
+  <mime-type type="image/urf">
+    <comment>Apple raster image</comment>
+    <glob pattern="*.apple"/>
+    <glob pattern="*.urf"/>
+  </mime-type>
+</mime-info>

--- a/test/maketestfiles.sh
+++ b/test/maketestfiles.sh
@@ -17,7 +17,6 @@ cspaces=""
 orders=""
 filter=""
 format="ras"
-FINAL_CONTENT_TYPE=application/vnd.cups-raster; export FINAL_CONTENT_TYPE
 if test -d /usr/libexec/cups/filter; then
 	filterpath="/usr/libexec/cups/filter"
 else
@@ -73,17 +72,14 @@ for option in $*; do
 			;;
 
 		apple)
-			FINAL_CONTENT_TYPE="image/urf"
 			format="apple"
 			;;
 
 		pwg)
-			FINAL_CONTENT_TYPE="image/pwg-raster"
 			format="pwg"
 			;;
 
 		ras)
-			FINAL_CONTENT_TYPE="application/vnd.cups-raster"
 			format="ras"
 			;;
 

--- a/urf.desktop
+++ b/urf.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Type=MimeType
-MimeType=image/urf
-Icon=rasterview.png
-Patterns=*.apple
-Name=Apple Raster File
-Comment=Apple Raster File
-Encoding=UTF-8

--- a/vnd.cups-raster.desktop
+++ b/vnd.cups-raster.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Type=MimeType
-MimeType=application/vnd.cups-raster
-Icon=rasterview.png
-Patterns=*.ras
-Name=CUPS Raster File
-Comment=CUPS Raster File
-Encoding=UTF-8


### PR DESCRIPTION
Few commits that improve the XDG desktop integration:
- drop support for non-XDG desktop directories: they are very old (last was KDE 3.x, which already supported XDG desktop directories)
- improve the application desktop file:
  - make it valid: `desktop-file-validate` is clean now
  - enhance/clean it a bit
  - install it in the right place
- add XDG MIME types for the two not already available in shared-mime-info 
- drop old desktop MIME type: they were used only by KDE up to 3.x, and nothing in rasterview refers to them

Even though I changed `configure.ac`, I did not regenerate `configure`; should it be rather dropped from the sources, and generated as needed (e.g. on dist or at build time)?